### PR TITLE
Fix expiry check bug in shared service

### DIFF
--- a/src/shared/shared.service.ts
+++ b/src/shared/shared.service.ts
@@ -87,17 +87,14 @@ export class SharedService {
 
   async isTokenExpired(
     createdAt: Date,
-    options: { expiresInHHours?: number; expiresInSeconds?: number },
+    options: { expiresInHours?: number; expiresInSeconds?: number },
   ) {
-    const expiry = options.expiresInSeconds || options.expiresInHHours;
-    const tokenExpirtyFactor = 1000 * 60 * options.expiresInHHours ? 60 : 1;
+    const expiry = options.expiresInSeconds ?? options.expiresInHours;
+    const tokenExpiryFactor = options.expiresInHours ? 1000 * 60 * 60 : 1000;
     const currentTime = Date.now();
     const timeDifferenceInMilliseconds = currentTime - createdAt.getTime();
-    const expiryTime = expiry * tokenExpirtyFactor; // convert hours to milliseconds
-    if (timeDifferenceInMilliseconds > expiryTime) {
-      return true;
-    }
-    return false;
+    const expiryTime = (expiry ?? 0) * tokenExpiryFactor; // convert to milliseconds
+    return timeDifferenceInMilliseconds > expiryTime;
   }
 
   // * Implement sending sms with twilio


### PR DESCRIPTION
## Summary
- fix `isTokenExpired` calculation

## Testing
- `npm test` *(fails: Your test suite must contain at least one test)*

------
https://chatgpt.com/codex/tasks/task_e_683f704e75b083298f338e4888fc03ce